### PR TITLE
Invert condition for return value work-around

### DIFF
--- a/src/aqt/cassowary/Strength.cpp
+++ b/src/aqt/cassowary/Strength.cpp
@@ -36,7 +36,7 @@ rhea::strength Strength::impl(Types t)
   case Weak:
     return rhea::strength::weak();
   }
-#if defined(_MSC_VER)
+#if !defined(__clang__)
   return rhea::strength::required();
 #endif
 }


### PR DESCRIPTION
Clang can tell that the switch covers all valid values of the enum, but other
compilers can not.

@ala-ableton please review.
