### PR TITLE
Bundle the qml plugin into the build dir

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,2 @@
 build
-qml/Aqt/Cassowary/qmldir
 output-doc

--- a/.travis.yml
+++ b/.travis.yml
@@ -15,5 +15,6 @@ before_script:
     - cmake .. -DCMAKE_BUILD_TYPE=$CONFIGURATION
 
 script:
-    - cmake --build .
-    - ctest -V
+    - cmake --build . --config $CONFIGURATION
+    - cmake --build . --config $CONFIGURATION --target install
+    - ctest -V -C $CONFIGURATION

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -77,6 +77,15 @@ set(CMAKE_INCLUDE_CURRENT_DIR ON)
 set(CMAKE_INCLUDE_CURRENT_DIR_IN_INTERFACE ON)
 set(CMAKE_MACOSX_RPATH ON)
 
+# We install aqt-cassowary within the build dir. It's up to you to
+# move it elsewhere.
+#
+# You can customize PLUGIN_INSTALL_DIR to be inside the Qt
+# distribution like all the other qml plugins, if you want to install
+# it system-wide.
+
+set(PLUGIN_INSTALL_DIR "${PROJECT_BINARY_DIR}/lib/qml")
+
 enable_testing()
 
 find_package(Qt5Quick 5.3.0 REQUIRED)

--- a/README.md
+++ b/README.md
@@ -62,12 +62,16 @@ Test dependencies:
   mkdir build
   cd build
   cmake ..
-  cmake --build .
+  cmake --build . --config Release
+  cmake --build . --config Release --target install
 ```
 
+The resulting plugin is then found inside `build/lib/qml`
+
 The unit tests can be executed with *ctest*:
+
 ```
-  ctest -V
+  ctest -V Release
 ```
 
 You might set the following variables:

--- a/qml/Aqt/Cassowary/qmldir
+++ b/qml/Aqt/Cassowary/qmldir
@@ -1,0 +1,4 @@
+module Aqt.Cassowary
+
+Stay 1.0 Stay.qml
+plugin AqtCassowaryPlugin

--- a/qml/Aqt/Cassowary/qmldir.in
+++ b/qml/Aqt/Cassowary/qmldir.in
@@ -1,4 +1,0 @@
-module Aqt.Cassowary
-
-Stay 1.0 Stay.qml
-plugin AqtCassowaryPlugin @PATH_TO_PLUGIN@

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -98,35 +98,15 @@ set_target_properties(AqtCassowaryPlugin
 set_target_properties(AqtCassowaryPlugin
   PROPERTIES LIBRARY_OUTPUT_DIRECTORY_RELEASE ${plugin_output})
 
-# rewrite qmldir to the plugin in the output folder (PATH_TO_PLUGIN is used
-# in qmldir.in)
-set(PATH_TO_PLUGIN "${PROJECT_BINARY_DIR}/output")
-configure_file(
-  "${PROJECT_SOURCE_DIR}/qml/Aqt/Cassowary/qmldir.in"
-  "${PROJECT_SOURCE_DIR}/qml/Aqt/Cassowary/qmldir"
-  @ONLY)
-unset(PATH_TO_PLUGIN)
-
-# prepare another qmldir, which we can use for installation
-set(PATH_TO_PLUGIN "")
-configure_file(
-  "${PROJECT_SOURCE_DIR}/qml/Aqt/Cassowary/qmldir.in"
-  "${plugin_output}/qmldir"
-  @ONLY)
-unset(PATH_TO_PLUGIN)
-
-set(PLUGIN_INSTALL_DIR "lib/qml")
 install(TARGETS AqtCassowaryPlugin
   LIBRARY DESTINATION "${PLUGIN_INSTALL_DIR}/Aqt/Cassowary")
-install(FILES "${plugin_output}/qmldir"
-  DESTINATION "${PLUGIN_INSTALL_DIR}/Aqt/Cassowary")
-install(DIRECTORY "${PROJECT_SOURCE_DIR}/qml/Aqt/Cassowary"
+install(DIRECTORY "${PROJECT_SOURCE_DIR}/qml/Aqt"
   DESTINATION "${PLUGIN_INSTALL_DIR}"
-  FILES_MATCHING REGEX ".*\\.(qml|js)$")
+  FILES_MATCHING REGEX "(qmldir|(.*\\.(qml|js)))$")
 
 # add tests
 add_test(AqtCassowaryTestCase
   qmltestrunner
-  -import "${PROJECT_SOURCE_DIR}/qml"
+  -import "${PLUGIN_INSTALL_DIR}"
   -import "${PROJECT_SOURCE_DIR}/compat/qml"
   -input "${PROJECT_SOURCE_DIR}/qml")


### PR DESCRIPTION
In order to have the test and test app run easily, we bundle the
plugin inside the build directory at installation step. Once this is
done the plugin can simply be imported using -I (qmlscene) or -import
(qmltestrunner)

While developing, you may opt-out of the installation step, and use
the -P (qmlscene) and -plugins (qmltestrunner) options to run test
applications and tests directly out of the source folder.

qmlscene and qmltestrunner both adopted these flags which allow
setting the directories containing plugins. This allows us to use a
simple static qmldir referring to the plugin module (dll/dylib) by
name without a computed path.