### PR TITLE
build: Update to latest Rhea and remove Boost dependency

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -90,11 +90,6 @@ enable_testing()
 
 find_package(Qt5Quick 5.3.0 REQUIRED)
 
-if(DEFINED Boost_INCLUDE_DIR)
-  get_filename_component(Boost_INCLUDE_DIR ${Boost_INCLUDE_DIR} ABSOLUTE)
-endif()
-find_package(Boost 1.54 REQUIRED)
-
 include(FeatureSummary)
 feature_summary(WHAT ALL FATAL_ON_MISSING_REQUIRED_PACKAGES)
 

--- a/README.md
+++ b/README.md
@@ -50,7 +50,6 @@ Requirements
 
 Dependencies:
   - Qt (>= 5.3)
-  - Boost (>= 1.54)
   - CMake (>= 2.8.12)
 
 Test dependencies:
@@ -74,17 +73,13 @@ The unit tests can be executed with *ctest*:
   ctest -V Release
 ```
 
-You might set the following variables:
-- `Boost_INCLUDE_DIR` to the folder, where Boost headers are found
-
 In case the CMake files shipped with Qt are not found, set the `CMAKE_PREFIX_PATH`
 to the Qt installation prefix. See the
 [Qt5 CMake manual](http://qt-project.org/doc/qt-5/cmake-manual.html) for more.
 
 Example:
 ```
-  cmake .. -DCMAKE_PREFIX_PATH=~/Qt/Qt5.3.1/clang_64 \
-           -DBoost_INCLUDE_DIR=/opt/local/include/
+  cmake .. -DCMAKE_PREFIX_PATH=~/Qt/Qt5.3.1/clang_64
 ```
 
 Maintainers

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -85,8 +85,7 @@ add_library(AqtCassowaryPlugin MODULE
 target_link_libraries(AqtCassowaryPlugin Rhea::Rhea Qt5::Quick)
 target_include_directories(AqtCassowaryPlugin PUBLIC
   "${PROJECT_SOURCE_DIR}/compat/src"
-  "${Rhea_INCLUDE_DIR}"
-  "${Boost_INCLUDE_DIRS}")
+  "${Rhea_INCLUDE_DIR}")
 target_compile_options(AqtCassowaryPlugin
   PUBLIC ${cxx11_options} ${warning_options})
 

--- a/src/aqt/cassowary/Context.hpp
+++ b/src/aqt/cassowary/Context.hpp
@@ -30,8 +30,8 @@ ABL_DISABLE_WARNINGS
 #include <QtQuick/QQuickItem>
 #include <rhea/simplex_solver.hpp>
 #include <rhea/iostream.hpp>
-#include <boost/lexical_cast.hpp>
 #include <queue>
+#include <sstream>
 ABL_RESTORE_WARNINGS
 
 namespace aqt {


### PR DESCRIPTION
Rhea had a dependency on Boost.Spirit, but this dependency was removed in https://github.com/Nocte-/rhea/commit/2a251df4db0aae2454daef8a9ad54c14b460dc09 (see also https://github.com/Nocte-/rhea/pull/43).  aqt-cassowary itself included Boost.LexicalCast, but Boost.LexicalCast was not used in the aqt-cassowary code.

The motivation for removing Boost is only to ensure that Qt/QML projects using aqt-cassowary do not have to import Boost if they do not use it for anything else.

I've run the test suite using Qt 5.10.1 (Linux x86-64) and Rhea `0f868a8e0f5ca9cf0bf75332d35842d21036b438`; on my machine, all tests passed.  The `splitters.qml`, `square-pusher.qml`, `quadrilaterals.qml`, and `point-in-a-box.qml` examples all appear to operate properly when run via `qmlscene`.